### PR TITLE
DECIMAL type missing

### DIFF
--- a/bdb/drivers/mysql.go
+++ b/bdb/drivers/mysql.go
@@ -310,7 +310,7 @@ func (m *MySQLDriver) TranslateColumnType(c bdb.Column) bdb.Column {
 			}
 		case "float":
 			c.Type = "null.Float32"
-		case "double", "double precision", "real":
+		case "double", "double precision", "real", "decimal":
 			c.Type = "null.Float64"
 		case "boolean", "bool":
 			c.Type = "null.Bool"


### PR DESCRIPTION
Decimal type fields are falling into the "default" and treated as string.